### PR TITLE
Add test plan for Librarian and update docs

### DIFF
--- a/home/codex/docs/gemini-librarian-service/README.md
+++ b/home/codex/docs/gemini-librarian-service/README.md
@@ -1,0 +1,12 @@
+# Gemini Librarian Service Docs
+
+This folder contains design material for the `aiq` Librarian service.
+
+* `spec.md` – high level specification
+* `implementation-plan.md` – stepwise plan to build the MVP
+* `test-plan.md` – how to verify the CLI works
+
+See also `home/agladysh/docs/firebase-studio/gemini-librarian-service/concept.md` and emails
+`mail/2025-07-03/10-alex-elara_thorne.eml` and `mail/2025-07-03/11-gemini-librarian-synthesis.eml`
+for additional context and design clues.
+

--- a/home/codex/docs/gemini-librarian-service/implementation-plan.md
+++ b/home/codex/docs/gemini-librarian-service/implementation-plan.md
@@ -1,0 +1,68 @@
+# Gemini Librarian Service: Implementation Plan
+
+This plan assumes development in a Unix-like shell environment (e.g., GFS) with Python 3 available. Adjust paths as needed. It follows design notes in `concept.md` and in the Elara Thorne email (`mail/2025-07-03/10-alex-elara_thorne.eml`).
+
+## 1. Repository Layout
+```
+/aiq/               # package root
+  cli.py            # entry point
+  tools.py          # retrieval and file access utilities
+  state/            # persistent conversations
+  templates/
+    system.j2
+logs/
+  aiq.log
+```
+
+## 2. Dependencies
+- Python 3.10+
+- `PyYAML` for YAML handling
+- `jinja2` for templating
+- Optional: `rich` for colored CLI output
+
+Install via `pip install -r requirements.txt`.
+
+## 3. CLI Workflow
+1. Read YAML from STDIN.
+2. Load or create conversation state directory.
+3. Render system message from template with tool list and environment info.
+4. Invoke Gemini API using provided messages.
+5. Save request/response pairs to state directory.
+6. Output the LLM reply to STDOUT.
+
+## 4. Tool Implementations
+### retrieve(query)
+- Use `grep -n` recursively under project root for `.md` and `.txt` files.
+- Return snippets with line numbers and paths.
+- Log query and number of hits.
+
+### os_read_file(path)
+- Try Python `open()` first.
+- On failure, run `cat <path>` using `subprocess`.
+- Capture stdout/stderr; return content or error string.
+
+## 5. Error Handling
+- Wrap all tool executions in try/except.
+- If any command fails, record the error message in the conversation state and include it in the LLM response.
+
+## 6. Logging
+- Append structured log entries to `logs/aiq.log`:
+  `timestamp tool action status message`
+- Keep logs short; rotate manually if needed.
+
+## 7. Testing
+The Librarian should include a minimal automated test suite.
+
+- **Unit tests** for `retrieve` and `os_read_file` using `pytest`.
+- **Integration test** executing `cli.py` on a sample YAML conversation and checking the log files and output.
+  - Provide a `tests/fixtures/` directory with small Markdown files.
+- Run `pytest` in CI (if available) or manually via `make test`.
+
+Manual E2E testing is still important: interact with `aiq` in a shell and confirm multi-turn state persistence.
+
+## 8. Deliverables
+- `aiq` CLI script with minimal features above.
+- Example template and configuration files.
+- Documentation (`spec.md` and this plan).
+
+

--- a/home/codex/docs/gemini-librarian-service/spec.md
+++ b/home/codex/docs/gemini-librarian-service/spec.md
@@ -1,0 +1,70 @@
+# Gemini Librarian Service Specification
+
+This document outlines the minimal viable feature set for the "Librarian" role running in Google Firebase Studio (GFS). It consolidates notes from `home/agladysh/docs/firebase-studio/gemini-librarian-service/concept.md` and recent team correspondence including `mail/2025-07-03/11-gemini-librarian-synthesis.eml`.
+
+## Goal
+Provide other AIs with reliable access to repository knowledge via a CLI tool (`aiq`). The Librarian answers retrieval queries by reading files, summarising content and returning references. Advanced features such as HSRS/memetics are future work.
+
+## Design Notes
+- Draws inspiration from Alex's `concept.md` and the Elara Thorne harness notes (`mail/2025-07-03/10-alex-elara_thorne.eml`).
+- The system message is rendered from a template on *every* request, embedding the current environment description and available tools.
+- Tools must emit clear error feedback so the LLM can self-correct.
+- All long‑term state lives on the filesystem because GFS chat memory is unreliable.
+- Start with a minimal toolset (`retrieve`, `os_read_file`); cognition loops and advanced retrieval come later.
+
+## Environment Constraints
+- Runs in GFS where tool calling can be unreliable and session context ephemeral.
+- File system state is persistent; use it for all conversation and query history.
+- Some tools (`read_file`) may fail randomly; fallback to `run_terminal_command` with `cat`.
+
+## Core Features
+1. **Command Line Interface (`aiq`)**
+   - Simple STDIN/STDOUT tool.
+   - Accepts conversation in YAML:
+     ```yaml
+     variables:
+       sys.role: |
+         You are Gemini ... in the role of Librarian.
+     conversation:
+       - user: | 
+           <query text>
+     ```
+   - Multi-turn: conversation state saved as YAML in a workspace folder.
+
+2. **Filesystem–Native State**
+   - Each conversation stored under `./state/aiq/<conversation-id>/`.
+   - Store: request/response logs, retrieved file paths, error messages.
+
+3. **Retrieval Tool** (`retrieve`)
+   - Input: `query` string, optional `remarks`.
+   - Implementation: simple grep over Markdown/text files under repository.
+   - Output: matching snippets with file paths.
+   - Future: indexing, advanced search.
+
+4. **File Reading Tool** (`os_read_file`)
+   - Primary method: internal read.
+   - Fallback: run `cat <path>` via `run_terminal_command` on failure.
+   - Returns file content or error message for the LLM.
+
+5. **Logging & Error Feedback**
+   - Log all tool calls and errors to `./logs/aiq.log`.
+   - When a tool fails, return a clear diagnostic message to the LLM so it can adjust the call.
+
+6. **Minimal System Message Template**
+   - Injects environment description and available tools at every request.
+   - Keep short to avoid blowing context.
+   - Example stub stored in `templates/system.j2`.
+
+## Non‑Goals (YAGNI)
+- No PDF conversion pipeline (performed externally).
+- No database or external index.
+- No network calls beyond LLM API and basic shell commands.
+- No complex authentication; local use only for now.
+
+## Future Work (Beyond MVP)
+- Advanced retrieval (concept search, HSRS/memetics).
+- MCP protocol server for inter-agent communication.
+- Additional cognition tools (`email`, `consult` etc.).
+- Robust indexing and caching of filesystem structure and file contents.
+
+

--- a/home/codex/docs/gemini-librarian-service/test-plan.md
+++ b/home/codex/docs/gemini-librarian-service/test-plan.md
@@ -1,0 +1,38 @@
+# Gemini Librarian Service: Test Plan
+
+This document outlines automated and manual tests for the `aiq` CLI. It expands on the brief notes in `implementation-plan.md`.
+
+## 1. Unit Tests
+
+Use `pytest` for unit tests.
+
+- **`retrieve()`**
+  - Works with sample Markdown files in `tests/fixtures/`.
+  - Verifies snippets include correct paths and line numbers.
+  - Simulate no matches to ensure graceful empty results.
+- **`os_read_file()`**
+  - Reads an existing file and returns its content.
+  - Simulates a read error (e.g. permission denied) and checks fallback to `cat`.
+
+## 2. Integration Test
+
+A simple test exercising the whole CLI:
+
+1. Create a temporary directory with fixture files and `state/`.
+2. Pipe a YAML conversation to `cli.py` requesting a file summary.
+3. Assert that the output contains expected text and that logs/state are written.
+4. Run the command twice to confirm conversation persistence.
+
+## 3. Manual Testing
+
+- Interact with `aiq` directly in a shell. Ensure conversations continue across invocations.
+- Test in a minimal GFS-like environment where tool calls occasionally fail to verify error handling.
+
+## 4. Running Tests
+
+```
+$ pip install -r requirements.txt
+$ pytest
+```
+
+If `pytest` is unavailable in CI, run tests manually before committing.

--- a/mail/2025-07-03/12-codex-onboarding.eml
+++ b/mail/2025-07-03/12-codex-onboarding.eml
@@ -1,0 +1,22 @@
+From: Codex
+To: Team
+Subject: Codex onboarding notes and Librarian spec draft
+
+Team,
+
+I have finished an initial onboarding pass as instructed in `AGENTS.md` and various README files. Key observations:
+
+* Repository roots: `README.md`, `AGENTS.md`, `TODO.md`, and `mail/` provide essential orientation. Home directories hold agent-specific notes.
+* Gemini's Librarian Service concept resides at `home/agladysh/docs/firebase-studio/gemini-librarian-service/concept.md`.
+* A synthesis of requirements is in `mail/2025-07-03/11-gemini-librarian-synthesis.eml`.
+* Fantastic Fishstick docs under `inbox/2025-06-21-6/` provide background design ideas.
+
+Following guidance, I created `home/codex/docs/gemini-librarian-service/` containing:
+
+* `spec.md` – a minimal spec for the `aiq` Librarian.
+* `implementation-plan.md` – stepwise plan for an MVP.
+
+Please review these documents. Feedback welcome.
+
+– Codex
+


### PR DESCRIPTION
## Summary
- mention test plan alongside spec and implementation plan
- link Elara email in implementation plan intro
- provide a new `test-plan.md` describing unit and integration tests

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6866885ed72883259f26e968a22f3571